### PR TITLE
For Facebook-PHP-SDK v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "facebook/php-sdk-v4": "4.0.23",
-        "facebook/php-ads-sdk": "2.3.1"
+        "facebook/php-sdk-v4": "5.1.0",
+        "facebook/php-ads-sdk": "2.4.2"
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.7.0"

--- a/src/ReFUEL4/Objects/BaseObject.php
+++ b/src/ReFUEL4/Objects/BaseObject.php
@@ -3,7 +3,6 @@
 namespace ReFUEL4\FacebookObject\Objects;
 
 use Facebook\FacebookRequest;
-use Facebook\FacebookSession;
 use ReFUEL4\FacebookObject\Repositories\BaseRepository;
 
 class BaseObject
@@ -20,17 +19,17 @@ class BaseObject
     /** @var array */
     protected $_data;
 
-    /** @var \Facebook\FacebookSession */
-    protected        $_session;
+    /** @var \Facebook\Facebook */
+    protected        $_facebook;
 
     /**
      * @param array $data
-     * @param \Facebook\FacebookSession $session
+     * @param \Facebook\Facebook $facebook
      */
-    public function __construct($data, $session)
+    public function __construct($data, $facebook)
     {
         $this->_data = $data;
-        $this->_session = $session;
+        $this->_facebook = $facebook;
     }
 
     public function __get($key)
@@ -40,7 +39,7 @@ class BaseObject
         }
         if (array_key_exists($key, static::$_edges)) {
             $path = $this->basePathForEdge() . $key;
-            $repository = new \ReFUEL4\FacebookObject\Repositories\BaseRepository($this->_session);
+            $repository = new \ReFUEL4\FacebookObject\Repositories\BaseRepository($this->_facebook);
             if (static::$_edges[$key]['isList']) {
                 return $repository->allWithClass($path, static::$_edges[$key]['object']);
             } else {

--- a/src/ReFUEL4/Repositories/AdImageRepository.php
+++ b/src/ReFUEL4/Repositories/AdImageRepository.php
@@ -32,7 +32,7 @@ class AdImageRepository extends BaseRepository
                 'id'   => $image->{\FacebookAds\Object\Fields\AdImageFields::ID},
                 'hash' => $image->{\FacebookAds\Object\Fields\AdImageFields::HASH},
             ],
-            $this->_session
+            $this->_facebook
         );
     }
 

--- a/src/ReFUEL4/Repositories/AdVideoRepository.php
+++ b/src/ReFUEL4/Repositories/AdVideoRepository.php
@@ -31,7 +31,7 @@ class AdVideoRepository extends BaseRepository
             [
                 'id' => $image->{\FacebookAds\Object\Fields\AdVideoFields::ID},
             ],
-            $this->_session
+            $this->_facebook
         );
     }
 

--- a/tests/ReFUEL4/ErrorTest.php
+++ b/tests/ReFUEL4/ErrorTest.php
@@ -7,8 +7,8 @@ class ErrorTest extends TestBase
     public function testGetError()
     {
 
-        $session = $this->getSession();
-        $repository = new \ReFUEL4\FacebookObject\Repositories\UserRepository($session);
+        $facebook = $this->getFacebook();
+        $repository = new \ReFUEL4\FacebookObject\Repositories\UserRepository($facebook);
 
         $error = $repository->find(4321);
 

--- a/tests/ReFUEL4/GetAccountTest.php
+++ b/tests/ReFUEL4/GetAccountTest.php
@@ -7,8 +7,8 @@ class GetAccountTest extends TestBase
     public function testAdAccount()
     {
 
-        $session = $this->getSession();
-        $repository = new \ReFUEL4\FacebookObject\Repositories\AdAccountRepository($session);
+        $facebook = $this->getFacebook();
+        $repository = new \ReFUEL4\FacebookObject\Repositories\AdAccountRepository($facebook);
         $adAccounts = $repository->all();
         $this->assertTrue(is_array($adAccounts));
 

--- a/tests/ReFUEL4/GetAdImageTest.php
+++ b/tests/ReFUEL4/GetAdImageTest.php
@@ -6,15 +6,15 @@ class GetAdImageTest extends TestBase
 {
     public function testAdImage()
     {
-        $session = $this->getSession();
-        $adAccountRepository = new \ReFUEL4\FacebookObject\Repositories\AdAccountRepository($session);
+        $facebook = $this->getFacebook();
+        $adAccountRepository = new \ReFUEL4\FacebookObject\Repositories\AdAccountRepository($facebook);
         $adAccounts = $adAccountRepository->all();
 
         $this->assertTrue(is_array($adAccounts));
 
         $adAccount = $adAccounts[0];
 
-        $adImageRepository = new \ReFUEL4\FacebookObject\Repositories\AdImageRepository($session);
+        $adImageRepository = new \ReFUEL4\FacebookObject\Repositories\AdImageRepository($facebook);
         $adImage = $adImageRepository->create($adAccount->id, realpath(dirname(__FILE__)) . '/media/sample.jpg');
 
         $this->assertNotEmpty($adImage->hash);

--- a/tests/ReFUEL4/GetAdVideoTest.php
+++ b/tests/ReFUEL4/GetAdVideoTest.php
@@ -6,15 +6,15 @@ class GetAdVideoTest extends TestBase
 {
     public function testAdVideo()
     {
-        $session = $this->getSession();
-        $adAccountRepository = new \ReFUEL4\FacebookObject\Repositories\AdAccountRepository($session);
+        $facebook = $this->getFacebook();
+        $adAccountRepository = new \ReFUEL4\FacebookObject\Repositories\AdAccountRepository($facebook);
         $adAccounts = $adAccountRepository->all();
 
         $this->assertTrue(is_array($adAccounts));
 
         $adAccount = $adAccounts[0];
 
-        $adVideoRepository = new \ReFUEL4\FacebookObject\Repositories\AdVideoRepository($session);
+        $adVideoRepository = new \ReFUEL4\FacebookObject\Repositories\AdVideoRepository($facebook);
         $adVideos = $adVideoRepository->all($adAccount->id);
         $this->assertTrue(is_array($adVideos));
         $this->assertInstanceOf('\ReFUEL4\FacebookObject\Objects\AdVideo', $adVideos[0], 'object is AdVideo');

--- a/tests/ReFUEL4/TestBase.php
+++ b/tests/ReFUEL4/TestBase.php
@@ -2,21 +2,24 @@
 
 namespace ReFUEL4\FacebookObject\Tests;
 
-use Facebook\FacebookSession;
 use FacebookAds\Api;
 
 abstract class TestBase extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @return \Facebook\FacebookSession
+     * @return \Facebook\Facebook
      */
-    public function getSession()
+    public function getFacebook()
     {
 
         $conf = json_decode(file_get_contents(realpath(dirname(__FILE__)) . '/config.json'));
         Api::init($conf->applicationId, $conf->applicationSecret, $conf->accessToken);
-        FacebookSession::setDefaultApplication($conf->applicationId, $conf->applicationSecret);
-
-        return new FacebookSession($conf->accessToken);
+        $facebook = new \Facebook\Facebook([
+            'app_id'                => $conf->applicationId,
+            'app_secret'            => $conf->applicationSecret,
+            'default_access_token'  => $conf->accessToken,
+            'default_graph_version' => 'v2.4',
+        ]);
+        return $facebook;
     }
 }

--- a/tests/ReFUEL4/UserTest.php
+++ b/tests/ReFUEL4/UserTest.php
@@ -7,7 +7,7 @@ class UserTest extends TestBase
     public function testGetMe()
     {
 
-        $session = $this->getSession();
+        $session = $this->getFacebook();
         $repository = new \ReFUEL4\FacebookObject\Repositories\UserRepository($session);
         $me = $repository->me();
 


### PR DESCRIPTION
[facebook/facebook-php-sdk-v4](https://github.com/facebook/facebook-php-sdk-v4)@4.0.23 supports GraphAPI v2.3 which is already deprecated version.

Update to use GraphAPI stable version(v2.4).
SDK has major update, then updated below points.
- removed FacebookSession class
- change FacebookSession args to Facebook Instance
